### PR TITLE
Lowered minSdkVersion to 14

### DIFF
--- a/proportionsbarlibrary/build.gradle
+++ b/proportionsbarlibrary/build.gradle
@@ -4,7 +4,7 @@ android {
     compileSdkVersion 28
 
     defaultConfig {
-        minSdkVersion 21
+        minSdkVersion 14
         targetSdkVersion 28
         versionCode 1
         versionName "0.1.1"

--- a/proportionsbarlibrary/src/main/java/com/github/proportionsbarlibrary/ProportionsBar.java
+++ b/proportionsbarlibrary/src/main/java/com/github/proportionsbarlibrary/ProportionsBar.java
@@ -7,6 +7,7 @@ import android.content.res.TypedArray;
 import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Paint;
+import android.graphics.RectF;
 import android.os.Parcel;
 import android.os.Parcelable;
 import android.support.annotation.Nullable;
@@ -231,7 +232,8 @@ public class ProportionsBar extends View {
     }
 
     private void drawArc(Canvas canvas, float start, float end, float h, int startAngle) {
-        canvas.drawArc(start, 0, end, h, startAngle, 180, true, paint);
+        RectF rect = new RectF(start, 0, end, h);
+        canvas.drawArc(rect, startAngle, 180, true, paint);
     }
 
     private void drawRectangle(Canvas canvas, float start, float end, float h) {

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -27,7 +27,7 @@ dependencies {
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
     //proportionsbarlibrary
-    implementation 'com.github.maxViolet:ProportionsBarLibrary:0.1.1'
-//    implementation project(":proportionsbarlibrary")
+    //implementation 'com.github.maxViolet:ProportionsBarLibrary:0.1.1'
+    implementation project(":proportionsbarlibrary")
 
 }


### PR DESCRIPTION
Hello, I like your library very much and it might be useful in some future apps that I have in mind.

I noticed that minSdkVersion is 21 which seems pretty high for this type of library. I changed drawArc method to use RectF object instead.

Note: Do not push sample/build.gradle file if you wish to keep using jitpack version of the library in the sample app.

Cheers ✌